### PR TITLE
Fixing 0 value given to executable

### DIFF
--- a/nipype/interfaces/niftyseg/maths.py
+++ b/nipype/interfaces/niftyseg/maths.py
@@ -190,6 +190,13 @@ class BinaryMaths(MathsCommand):
 
     """
     input_spec = BinaryMathsInput
+  
+    def _format_arg(self, opt, spec, val):
+        """Convert input to appropriate format for niftkMTPDbc."""
+        if opt == 'operand_value' and float(val) == 0.0:
+            return '0'
+
+        return super(BinaryMaths, self)._format_arg(opt, spec, val)
 
 
 class BinaryMathsInputInteger(MathsInput):

--- a/nipype/interfaces/niftyseg/maths.py
+++ b/nipype/interfaces/niftyseg/maths.py
@@ -192,7 +192,7 @@ class BinaryMaths(MathsCommand):
     input_spec = BinaryMathsInput
   
     def _format_arg(self, opt, spec, val):
-        """Convert input to appropriate format for niftkMTPDbc."""
+        """Convert input to appropriate format for seg_maths."""
         if opt == 'operand_value' and float(val) == 0.0:
             return '0'
 


### PR DESCRIPTION
Hi,

I realized that two operations don't work if you use 0 as a value (thr and uthr). The interface set the value to 0.000000 when you give zero as an operand value. The executable failed if you give zero with decimals. 

I added some extra lines of code in _format_arg to check wheter or not the value is 0. If so, return the value zero without decimal.

Kind Regards,

Ben
